### PR TITLE
Add simply CI with GItHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,34 @@ jobs:
           TEST_PHP_ARGS: '-q --show-diff'
         run: |
           make test
+  Linux_Fedora:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fedora: [39, 40, 41]
+        php: ['8.0', '8.1', '8.2', '8.3']
+    container:
+      image: fedora:${{ matrix.fedora }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install PHP
+        run: |
+          dnf install -y "https://rpms.remirepo.net/fedora/remi-release-${{ matrix.fedora }}.rpm"
+          dnf --enablerepo=remi-modular module enable -y "php:remi-${{ matrix.php }}"
+          dnf --enablerepo=remi,remi-modular install -y "php" "php-devel"
+      - name: Show PHP version
+        run: php -v
+      - name: Make php-xpass
+        run: |
+          phpize
+          ./configure
+          make -j"$(nproc)"
+      - name: Test php-xpass
+        env:
+          TEST_PHP_ARGS: '-q --show-diff'
+        run: |
+          make test
   Linux_Debian:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,55 @@ on:
         - master
   pull_request:
 jobs:
-  Linux:
+  Linux_EL:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: ['rockylinux']
+        el: [8, 9]
+        php: ['8.2', '8.3']
+        include:
+          - distro: 'rockylinux'
+            el: 8
+            php: '8.0'
+          - distro: 'rockylinux'
+            el: 8
+            php: '8.1'
+    container:
+      image: ${{ matrix.distro }}:${{ matrix.el }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install PHP
+        run: |
+          dnf install -y "https://rpms.remirepo.net/enterprise/remi-release-${{ matrix.el }}.rpm"
+          dnf config-manager --disable -y "epel" "remi-modular" "remi-safe"
+          dnf --enablerepo=remi-modular module enable -y "php:remi-${{ matrix.php }}"
+          dnf --enablerepo=epel,remi,remi-modular install -y "php" "php-devel"
+      - name: Show PHP version
+        run: php -v
+      - name: Manually install libxcrypt 4.4.x (EL8 and earlier)
+        if: ${{ matrix.el < 9 }}
+        run: |
+          dnf install -y "python3-pip" "perl-open" "git"
+          pip3 install "passlib"
+          git clone --depth=1 --branch="v4.4.36" "https://github.com/besser82/libxcrypt.git" "libxcrypt"
+          cd "libxcrypt"
+          ./autogen.sh
+          ./configure --with-pkgconfigdir="/usr/lib64/pkgconfig" --libdir="/usr/lib64"
+          make -j"$(nproc)"
+          make install
+      - name: Make php-xpass
+        run: |
+          phpize
+          ./configure
+          make -j"$(nproc)"
+      - name: Test php-xpass
+        env:
+          TEST_PHP_ARGS: '-q --show-diff'
+        run: |
+          make test
+  Linux_Debian:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,7 @@ jobs:
       matrix:
         distro: ['rockylinux']
         el: [8, 9]
-        php: ['8.2', '8.3']
-        include:
-          - distro: 'rockylinux'
-            el: 8
-            php: '8.0'
-          - distro: 'rockylinux'
-            el: 8
-            php: '8.1'
+        php: ['8.0', '8.1', '8.2', '8.3']
     container:
       image: ${{ matrix.distro }}:${{ matrix.el }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-        - main
+        - master
   pull_request:
 jobs:
   Linux:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+on:
+  push:
+    branches:
+        - main
+  pull_request:
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3']
+        ts: ['cli', 'zts']
+        xcrypt: ['master']
+    container:
+      image: php:${{ matrix.php }}-${{ matrix.ts }}
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y "automake" "libtool"
+      - name: Clone libxcrypt
+        uses: actions/checkout@v4
+        with:
+          repository: besser82/libxcrypt
+          ref: ${{ matrix.xcrypt }}
+          path: libxcrypt
+      - name: Install libxcrypt
+        working-directory: ${{ github.workspace }}/libxcrypt
+        run: |
+          ./autogen.sh
+          ./configure
+          make -j"$(nproc)"
+          make install
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Make xpass
+        run: |
+          phpize
+          ./configure
+          make -j"$(nproc)"
+      - name: Test xpass
+        env:
+          TEST_PHP_ARGS: '-q --show-diff'
+        run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,27 +11,13 @@ jobs:
       matrix:
         php: ['8.0', '8.1', '8.2', '8.3']
         ts: ['cli', 'zts']
-        xcrypt: ['master']
     container:
       image: php:${{ matrix.php }}-${{ matrix.ts }}
     steps:
       - name: Install build dependencies
         run: |
           apt-get update
-          apt-get install -y "automake" "libtool"
-      - name: Clone libxcrypt
-        uses: actions/checkout@v4
-        with:
-          repository: besser82/libxcrypt
-          ref: ${{ matrix.xcrypt }}
-          path: libxcrypt
-      - name: Install libxcrypt
-        working-directory: ${{ github.workspace }}/libxcrypt
-        run: |
-          ./autogen.sh
-          ./configure
-          make -j"$(nproc)"
-          make install
+          apt-get install -y "automake" "libtool" "libcrypt-dev"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Make xpass

--- a/tests/sha512.phpt
+++ b/tests/sha512.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check if xpass is loaded
+Check sha512 algo
 --EXTENSIONS--
 xpass
 --SKIPIF--

--- a/tests/yescrypt.phpt
+++ b/tests/yescrypt.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check if xpass is loaded
+Check yescrypt algo
 --EXTENSIONS--
 xpass
 --SKIPIF--


### PR DESCRIPTION
Add simple CI using GitHub Actions

Initially, we'll test PHP versions 8.0 to 8.3 as specified in the README.md.
We'll use the DockerHub official (not PHP Group) PHP prebuild container images.

This CI does not include checks using Valgrind or MemorySanitizer. If needed, please let me know, and I'll add them :)

example result:
https://github.com/zeriyoshi/php-xpass/actions/runs/10667357550