### PR TITLE
Add config.w32 to allow building on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,14 @@
+ARG_ENABLE("xpass", "Enable xpass support", "no");
+
+if (PHP_XPASS != "no") {
+    if (CHECK_LIB("crypt.lib", "xpass", PHP_XPASS)
+     && CHECK_HEADER_ADD_INCLUDE("crypt.h", "CLFAGS_XPASS", PHP_XPASS)
+     && CHECK_LIB("bcrypt.lib", "xpass", PHP_XPASS)) {
+        AC_DEFINE("HAVE_XPASS", 1, "Have xpass support");
+        EXTENSION("xpass", "xpass.c");
+        AC_DEFINE("HAVE_CRYPT_YESCRYPT", 1, "Have yescrypt hash support");
+        AC_DEFINE("HAVE_CRYPT_SHA512", 1, "Have sha512 hash support");
+    } else {
+        WARNING("xpass not enabled; libraries and headers not found");
+    }
+}


### PR DESCRIPTION
There is [apparently some interest in using php-xpass on Windows](https://github.com/besser82/libxcrypt/issues/193), so I gave it a try, and it seems to be working.

Contrary to config.m4, config.w32 uses the "classic" checking for libraries and headers since pkg-config is not ([yet](https://github.com/php/php-src/pull/16830)) supported on Windows. SHA512 and yescript support are simply assumed to be available in the library (no `AC_RUN_IFELSE` or similar are supported for the Windows build chain).