### PR TITLE
Add Windows support in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,40 @@ name: CI
 on:
   push:
     branches:
-        - master
+      - master
+    tags:
+      - '*'
   pull_request:
 jobs:
+  Windows_Matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.extension-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get Windows extension matrix
+        id: extension-matrix
+        uses: php/php-windows-builder/extension-matrix@v1
+
+  Windows:
+    name: Windows_${{ matrix.php-version }}_${{ matrix.arch }}_${{ matrix.ts }}
+    needs: Windows_Matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.Windows_Matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and test Windows extension
+        uses: php/php-windows-builder/extension@v1
+        with:
+          php-version: ${{ matrix.php-version }}
+          arch: ${{ matrix.arch }}
+          ts: ${{ matrix.ts }}
+          libs: libxcrypt
+          test-runner-args: -q --show-diff
   Linux_EL9:
     runs-on: ubuntu-latest
     strategy:
@@ -127,3 +158,16 @@ jobs:
         env:
           TEST_PHP_ARGS: '-q --show-diff'
         run: make test
+  Windows_Release:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    needs: [Windows, Linux_EL9, Linux_EL10, Linux_Fedora, Linux_Debian]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Upload Windows artifacts to release
+        uses: php/php-windows-builder/release@v1
+        with:
+          release: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/config.w32
+++ b/config.w32
@@ -2,12 +2,13 @@ ARG_ENABLE("xpass", "Enable xpass support", "no");
 
 if (PHP_XPASS != "no") {
     if (CHECK_LIB("crypt.lib", "xpass", PHP_XPASS)
-     && CHECK_HEADER_ADD_INCLUDE("crypt.h", "CLFAGS_XPASS", PHP_XPASS)
+     && CHECK_HEADER_ADD_INCLUDE("crypt.h", "CFLAGS_XPASS", PHP_XPASS)
      && CHECK_LIB("bcrypt.lib", "xpass", PHP_XPASS)) {
         AC_DEFINE("HAVE_XPASS", 1, "Have xpass support");
         EXTENSION("xpass", "xpass.c");
         AC_DEFINE("HAVE_CRYPT_YESCRYPT", 1, "Have yescrypt hash support");
         AC_DEFINE("HAVE_CRYPT_SHA512", 1, "Have sha512 hash support");
+        AC_DEFINE("HAVE_CRYPT_SM3", 1, "Have SM3 hash support");
     } else {
         WARNING("xpass not enabled; libraries and headers not found");
     }


### PR DESCRIPTION
supersedes #5 

It adds Windows jobs and also makes the workflow run when tags are pushed, so that a release can be created for the tag with windows builds that php/pie can use.